### PR TITLE
feat: flush queues in beforeunload handler

### DIFF
--- a/src/common/apm-server.js
+++ b/src/common/apm-server.js
@@ -27,6 +27,7 @@ class ApmServer {
 
     this.initErrorQueue()
     this.initTransactionQueue()
+    this.initBeforeUnloadListener()
   }
 
   createServiceObject () {
@@ -150,6 +151,22 @@ class ApmServer {
         interval: interval
       })
   }
+
+  initBeforeUnloadListener () {
+    var self = this
+
+    window.addEventListener('beforeunload', function () {
+      if (self._configService.isActive()) {
+        if (self.transactionQueue) {
+          self.transactionQueue.flush()
+        }
+        if (self.errorQueue) {
+          self.errorQueue.flush()
+        }
+      }
+    })
+  }
+
   addError (error) {
     if (this._configService.isActive()) {
       if (!this.errorQueue) {


### PR DESCRIPTION
There is 1 quirk to note: unload page handlers are messing with back forward cache and this is breaks mobile UX. There also `pagehide` event but on my chrome http request isn't fired while transaction flushed inside `beforeunload` handler are sent to the apm server. 

`navigator.sendBeacon` could be used in conjunction with `pagehide` event.