### PR TITLE
fix: use dist package for url-parse to avoid packaging issues

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -86,7 +86,7 @@ function isDtHeaderValid (header) {
   )
 }
 
-var URL = require('url-parse')
+var URL = require('url-parse/dist/url-parse')
 
 function isSameOrigin (source, target) {
   var isSame = false


### PR DESCRIPTION
Fixes elastic/apm-agent-js-base#110