### PR TITLE
feat: include transaction flags on error

### DIFF
--- a/src/error-logging/error-logging.js
+++ b/src/error-logging/error-logging.js
@@ -3,10 +3,11 @@ var StackTraceService = require('./stack-trace-service')
 var utils = require('../common/utils')
 
 class ErrorLogging {
-  constructor (apmServer, configService, loggingService) {
+  constructor (apmServer, configService, loggingService, transactionService) {
     this._apmServer = apmServer
     this._configService = configService
     this._loggingService = loggingService
+    this._transactionService = transactionService
     this._stackTraceService = new StackTraceService(configService, loggingService)
   }
 
@@ -66,6 +67,15 @@ class ErrorLogging {
         type: utils.sanitizeString(errorType, stringLimit, false)
       },
       context: context
+    }
+
+    var currentTransaction = this._transactionService.getCurrentTransaction()
+    if (currentTransaction) {
+      errorObject.transaction_id = currentTransaction.id
+      errorObject.transaction = {
+        type: currentTransaction.type,
+        sampled: currentTransaction.sampled
+      }
     }
     return errorObject
   }

--- a/src/error-logging/error-logging.js
+++ b/src/error-logging/error-logging.js
@@ -71,6 +71,8 @@ class ErrorLogging {
 
     var currentTransaction = this._transactionService.getCurrentTransaction()
     if (currentTransaction) {
+      errorObject.trace_id = currentTransaction.traceId
+      errorObject.parent_id = currentTransaction.id
       errorObject.transaction_id = currentTransaction.id
       errorObject.transaction = {
         type: currentTransaction.type,

--- a/src/error-logging/index.js
+++ b/src/error-logging/index.js
@@ -1,13 +1,14 @@
-var ErrorLogging = require('./error-logging')
+const ErrorLogging = require('./error-logging')
 
 module.exports = {
   ErrorLogging: ErrorLogging,
   registerServices: function registerServices (serviceFactory) {
     serviceFactory.registerServiceCreator('ErrorLogging', function () {
-      var apmService = serviceFactory.getService('ApmServer')
-      var configService = serviceFactory.getService('ConfigService')
-      var loggingService = serviceFactory.getService('LoggingService')
-      return new ErrorLogging(apmService, configService, loggingService)
+      const apmService = serviceFactory.getService('ApmServer')
+      const configService = serviceFactory.getService('ConfigService')
+      const loggingService = serviceFactory.getService('LoggingService')
+      const transactionService = serviceFactory.getService('TransactionService')
+      return new ErrorLogging(apmService, configService, loggingService, transactionService)
     })
   }
 }

--- a/test/error-logging/error-logging.spec.js
+++ b/test/error-logging/error-logging.spec.js
@@ -6,19 +6,22 @@ describe('ErrorLogging', function () {
   var configService
   var apmServer
   var errorLogging
+  var transactionService
   beforeEach(function () {
     var serviceFactory = createServiceFactory()
     configService = serviceFactory.getService('ConfigService')
     configService.setConfig(apmTestConfig)
     apmServer = serviceFactory.getService('ApmServer')
     errorLogging = serviceFactory.getService('ErrorLogging')
+    transactionService = serviceFactory.getService('TransactionService')
   })
 
   it('should send error', function (done) {
+    var errorObject
     try {
       throw new Error('test error')
     } catch (error) {
-      var errorObject = errorLogging.createErrorDataModel({ error: error })
+      errorObject = errorLogging.createErrorDataModel({ error })
     }
     apmServer.sendErrors([errorObject]).then(
       function () {
@@ -45,7 +48,7 @@ describe('ErrorLogging', function () {
       error.anObject = obj
       error.aFunction = function noop () {}
       error.null = null
-      errorLogging.logErrorEvent({ error: error }, true).then(
+      errorLogging.logErrorEvent({ error }, true).then(
         function () {
           expect(apmServer.sendErrors).toHaveBeenCalled()
           var errors = apmServer.sendErrors.calls.argsFor(0)[0]
@@ -64,6 +67,21 @@ describe('ErrorLogging', function () {
       )
     }
   })
+
+  it('should include transaction details on error', () => {
+    var transaction = transactionService.startTransaction('test', 'dummy')
+    try {
+      throw new Error('Test Error')
+    } catch (error) {
+      var errorData = errorLogging.createErrorDataModel({ error })
+      expect(errorData.transaction_id).toEqual(transaction.id)
+      expect(errorData.transaction).toEqual({
+        type: transaction.type,
+        sampled: transaction.sampled
+      })
+    }
+  })
+
   function createErrorEvent (message) {
     var errorEvent
     var errorEventData = {
@@ -170,8 +188,8 @@ describe('ErrorLogging', function () {
     try {
       throw new Error('unittest error')
     } catch (error) {
-      errorLogging.logErrorEvent({ error: error })
-      errorLogging.logErrorEvent({ error: error })
+      errorLogging.logErrorEvent({ error })
+      errorLogging.logErrorEvent({ error })
       errorLogging.logError(error)
       errorLogging.logError('test error')
       expect(apmServer.sendErrors).not.toHaveBeenCalled()
@@ -189,8 +207,8 @@ describe('ErrorLogging', function () {
     try {
       throw new Error('unittest error')
     } catch (error) {
-      errorLogging.logErrorEvent({ error: error })
-      errorLogging.logErrorEvent({ error: error })
+      errorLogging.logErrorEvent({ error })
+      errorLogging.logErrorEvent({ error })
       errorLogging.logError(error)
       errorLogging.logError('test error')
       expect(apmServer.sendErrors).not.toHaveBeenCalled()


### PR DESCRIPTION
+ Add the transaction flags such as id, type and sampled flags to the error object while sending to apm server
+ fixes #https://github.com/elastic/apm-agent-js-base/issues/131 https://github.com/elastic/apm-agent-js-base/issues/139 https://github.com/elastic/apm-agent-js-base/issues/40