### PR TITLE
fix: propagate transaction ID for unsampled transactions

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -70,14 +70,19 @@ function parseUrl (url) {
   }
 }
 
-const dtVersion = '00'
-const dtUnSampledFlags = '00'
-// 00000001 ->  '01' -> recorded
-const dtSampledFlags = '01'
 function getDtHeaderValue (span) {
-  if (span && span.traceId && span.id) {
+  const dtVersion = '00'
+  const dtUnSampledFlags = '00'
+  // 00000001 ->  '01' -> recorded
+  const dtSampledFlags = '01'
+  if (span && span.traceId && span.id && span.parentId) {
     var flags = span.sampled ? dtSampledFlags : dtUnSampledFlags
-    return dtVersion + '-' + span.traceId + '-' + span.id + '-' + flags
+    /**
+     * In the case of unsampled traces, propagate transaction id (parentId)
+     * instead of span id to the downstream
+     */
+    var id = span.sampled ? span.id : span.parentId
+    return dtVersion + '-' + span.traceId + '-' + id + '-' + flags
   }
 }
 

--- a/test/common/utils.spec.js
+++ b/test/common/utils.spec.js
@@ -233,13 +233,17 @@ describe('lib/utils', function () {
   })
 
   it('should generate correct DT headers', function () {
-    var span = new Span('test', 'test', { sampled: true, traceId: 'traceId' })
+    var span = new Span('test', 'test', {
+      sampled: true,
+      traceId: 'traceId',
+      parentId: 'transcationId'
+    })
     span.id = 'spanId'
     var headerValue = utils.getDtHeaderValue(span)
     expect(headerValue).toBe('00-traceId-spanId-01')
     span.sampled = false
     headerValue = utils.getDtHeaderValue(span)
-    expect(headerValue).toBe('00-traceId-spanId-00')
+    expect(headerValue).toBe('00-traceId-transcationId-00')
   })
 
   it('should validate DT header', function () {


### PR DESCRIPTION
+ fixes https://github.com/elastic/apm-agent-js-base/issues/98