### PR TITLE
chore: remove all array polyfills

### DIFF
--- a/src/common/config-service.js
+++ b/src/common/config-service.js
@@ -23,15 +23,7 @@
  *
  */
 
-const {
-  getCurrentScript,
-  arrayMap,
-  arrayReduce,
-  arraySome,
-  sanitizeString,
-  setTag,
-  merge
-} = require('./utils')
+const { getCurrentScript, sanitizeString, setTag, merge } = require('./utils')
 const Subscription = require('../common/subscription')
 const constants = require('./constants')
 
@@ -54,11 +46,14 @@ function getDataAttributesFromNode (node) {
       var key = attr.nodeName.match(dataRegex)[1]
 
       // camelCase key
-      key = arrayMap(key.split('-'), function (group, index) {
-        return index > 0 ? group.charAt(0).toUpperCase() + group.substring(1) : group
-      }).join('')
+      var camelCasedkey = key
+        .split('-')
+        .map((value, index) => {
+          return index > 0 ? value.charAt(0).toUpperCase() + value.substring(1) : value
+        })
+        .join('')
 
-      dataAttrs[key] = attr.value || attr.nodeValue
+      dataAttrs[camelCasedkey] = attr.value || attr.nodeValue
     }
   }
 
@@ -147,13 +142,9 @@ class Config {
   }
 
   get (key) {
-    return arrayReduce(
-      key.split('.'),
-      function (obj, i) {
-        return obj && obj[i]
-      },
-      this.config
-    )
+    return key.split('.').reduce((obj, objKey) => {
+      return obj && obj[objKey]
+    }, this.config)
   }
 
   getEndpointUrl () {
@@ -166,9 +157,10 @@ class Config {
     var maxLevel = levels.length - 1
     var target = this.config
 
-    arraySome(levels, function (level, i) {
-      if (typeof level === 'undefined') {
-        return true
+    for (let i = 0; i < maxLevel + 1; i++) {
+      const level = levels[i]
+      if (!level) {
+        continue
       }
       if (i === maxLevel) {
         target[level] = value
@@ -177,7 +169,7 @@ class Config {
         target[level] = obj
         target = obj
       }
-    })
+    }
   }
 
   setUserContext (userContext) {

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -298,6 +298,20 @@ function getCurrentScript () {
   }
 }
 
+function extend (dst) {
+  return baseExtend(dst, slice.call(arguments, 1), false)
+}
+
+function merge (dst) {
+  return baseExtend(dst, slice.call(arguments, 1), true)
+}
+
+function isUndefined (obj) {
+  return typeof obj === 'undefined'
+}
+
+function noop () {}
+
 function find (array, predicate, thisArg) {
   // Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
   if (array == null) {
@@ -329,104 +343,10 @@ function removeInvalidChars (key) {
 }
 
 module.exports = {
-  extend: function extend (dst) {
-    return baseExtend(dst, slice.call(arguments, 1), false)
-  },
-
-  merge: function merge (dst) {
-    return baseExtend(dst, slice.call(arguments, 1), true)
-  },
-
-  arrayReduce: function (arrayValue, callback, value) {
-    // Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
-    if (arrayValue == null) {
-      throw new TypeError('Array.prototype.reduce called on null or undefined')
-    }
-    if (typeof callback !== 'function') {
-      throw new TypeError(callback + ' is not a function')
-    }
-    var t = Object(arrayValue)
-    var len = t.length >>> 0
-    var k = 0
-
-    if (!value) {
-      while (k < len && !(k in t)) {
-        k++
-      }
-      if (k >= len) {
-        throw new TypeError('Reduce of empty array with no initial value')
-      }
-      value = t[k++]
-    }
-
-    for (; k < len; k++) {
-      if (k in t) {
-        value = callback(value, t[k], k, t)
-      }
-    }
-    return value
-  },
-
-  arraySome: function (value, callback, thisArg) {
-    // Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some
-    if (value == null) {
-      throw new TypeError('Array.prototype.some called on null or undefined')
-    }
-
-    if (typeof callback !== 'function') {
-      throw new TypeError()
-    }
-
-    var t = Object(value)
-    var len = t.length >>> 0
-
-    if (!thisArg) {
-      thisArg = void 0
-    }
-
-    for (var i = 0; i < len; i++) {
-      if (i in t && callback.call(thisArg, t[i], i, t)) {
-        return true
-      }
-    }
-    return false
-  },
-
-  arrayMap: function (arrayValue, callback, thisArg) {
-    // Source https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Map
-    var T, A, k
-
-    if (this == null) {
-      throw new TypeError(' this is null or not defined')
-    }
-    var O = Object(arrayValue)
-    var len = O.length >>> 0
-
-    if (typeof callback !== 'function') {
-      throw new TypeError(callback + ' is not a function')
-    }
-    if (arguments.length > 1) {
-      T = thisArg
-    }
-    A = new Array(len)
-    k = 0
-    while (k < len) {
-      var kValue, mappedValue
-      if (k in O) {
-        kValue = O[k]
-        mappedValue = callback.call(T, kValue, k, O)
-        A[k] = mappedValue
-      }
-      k++
-    }
-    return A
-  },
-
-  isUndefined: function (obj) {
-    return typeof obj === 'undefined'
-  },
-
-  noop: function () {},
+  extend,
+  merge,
+  isUndefined,
+  noop,
   baseExtend,
   bytesToHex,
   isCORSSupported,

--- a/test/common/config-service.spec.js
+++ b/test/common/config-service.spec.js
@@ -177,4 +177,17 @@ describe('ConfigService', function () {
       date: String(date)
     })
   })
+
+  it('should set config from script data attributes', () => {
+    const script = document.createElement('script')
+    script.src = './elastic-script.js'
+    script.setAttribute('data-service-name', 'js-core')
+    script.setAttribute('data-capture-page-load', 'false')
+    document.head.appendChild(script)
+
+    const configServiceFromScript = new ConfigService()
+    configServiceFromScript.init()
+    expect(configServiceFromScript.get('serviceName')).toBe('js-core')
+    expect(configServiceFromScript.get('capturePageLoad')).toBe('false')
+  })
 })


### PR DESCRIPTION
+ the imported polyfills are supported in all browsers that we target currently except Array.find which is modifed with simple for of loop
+ **BUNDLE SIZE** reduced by 1kb minified