### PR TITLE
perf: avoid url parsing on resource timing entries

### DIFF
--- a/src/common/apm-server.js
+++ b/src/common/apm-server.js
@@ -121,10 +121,7 @@ class ApmServer {
   _createQueue (onFlush) {
     var queueLimit = this._configService.get('queueLimit')
     var flushInterval = this._configService.get('flushInterval')
-    return new Queue(onFlush, {
-      queueLimit: queueLimit,
-      flushInterval: flushInterval
-    })
+    return new Queue(onFlush, { queueLimit, flushInterval })
   }
 
   initErrorQueue () {
@@ -149,10 +146,7 @@ class ApmServer {
       function () {
         apmServer._loggingService.warn('Dropped error due to throttling!')
       },
-      {
-        limit: limit,
-        interval: interval
-      }
+      { limit, interval }
     )
   }
 
@@ -178,10 +172,7 @@ class ApmServer {
       function () {
         apmServer._loggingService.warn('Dropped transaction due to throttling!')
       },
-      {
-        limit: limit,
-        interval: interval
-      }
+      { limit, interval }
     )
   }
 
@@ -221,16 +212,15 @@ class ApmServer {
   sendErrors (errors) {
     if (this._configService.isValid() && this._configService.isActive()) {
       if (errors && errors.length > 0) {
-        var payload = {
+        const payload = {
           service: this.createServiceObject(),
-          errors: errors
+          errors
         }
-
-        payload = this._configService.applyFilters(payload)
-        if (payload) {
+        const filteredPayload = this._configService.applyFilters(payload)
+        if (filteredPayload) {
           var endPoint = this._configService.getEndpointUrl('errors')
-          var ndjson = this.ndjsonErrors(payload.errors)
-          ndjson.unshift(NDJSON.stringify({ metadata: { service: payload.service } }))
+          var ndjson = this.ndjsonErrors(filteredPayload.errors)
+          ndjson.unshift(NDJSON.stringify({ metadata: { service: filteredPayload.service } }))
           var ndjsonPayload = ndjson.join('')
           return this._postJson(endPoint, ndjsonPayload)
         } else {
@@ -262,16 +252,16 @@ class ApmServer {
   sendTransactions (transactions) {
     if (this._configService.isValid() && this._configService.isActive()) {
       if (transactions && transactions.length > 0) {
-        var payload = {
+        const payload = {
           service: this.createServiceObject(),
-          transactions: transactions
+          transactions
         }
-        payload = this._configService.applyFilters(payload)
-        if (payload) {
-          var endPoint = this._configService.getEndpointUrl('transactions')
-          var ndjson = this.ndjsonTransactions(payload.transactions)
-          ndjson.unshift(NDJSON.stringify({ metadata: { service: payload.service } }))
-          var ndjsonPayload = ndjson.join('')
+        const filteredPayload = this._configService.applyFilters(payload)
+        if (filteredPayload) {
+          const endPoint = this._configService.getEndpointUrl('transactions')
+          const ndjson = this.ndjsonTransactions(filteredPayload.transactions)
+          ndjson.unshift(NDJSON.stringify({ metadata: { service: filteredPayload.service } }))
+          const ndjsonPayload = ndjson.join('')
           return this._postJson(endPoint, ndjsonPayload)
         } else {
           this._loggingService.warn('Dropped payload due to filtering!')

--- a/src/performance-monitoring/capture-hard-navigation.js
+++ b/src/performance-monitoring/capture-hard-navigation.js
@@ -24,7 +24,7 @@
  */
 
 const Span = require('./span')
-const Url = require('../common/url')
+const { stripQueryStringFromUrl } = require('../common/utils')
 
 const eventPairs = [
   ['domainLookupStart', 'domainLookupEnd', 'Domain lookup'],
@@ -115,14 +115,16 @@ function createResourceTimingSpans (entries, filterUrls) {
         start < spanThreshold &&
         end < spanThreshold
       ) {
-        var parsedUrl = new Url(name)
-        var spanName = parsedUrl.origin + parsedUrl.path
-        var span = new Span(spanName || name, kind)
-        span.addContext({
-          http: {
-            url: name
-          }
-        })
+        var spanName = stripQueryStringFromUrl(name)
+        var span = new Span(spanName, kind)
+        /**
+         * Add context information when the span name and entry name are different
+         */
+        if (spanName !== name) {
+          span.addContext({
+            http: { url: name }
+          })
+        }
         span._start = start
         span.ended = true
         span._end = end

--- a/src/performance-monitoring/performance-monitoring.js
+++ b/src/performance-monitoring/performance-monitoring.js
@@ -204,12 +204,12 @@ class PerformanceMonitoring {
   }
 
   createTransactionDataModel (transaction) {
-    var configContext = this._configService.get('context')
-    var stringLimit = this._configService.get('serverStringLimit')
-    var transactionStart = transaction._start
+    const configContext = this._configService.get('context')
+    const stringLimit = this._configService.get('serverStringLimit')
+    const transactionStart = transaction._start
 
-    var spans = transaction.spans.map(function (span) {
-      var context
+    const spans = transaction.spans.map(function (span) {
+      let context
       if (span.context) {
         context = sanitizeObjectStrings(span.context, stringLimit)
       }
@@ -225,19 +225,19 @@ class PerformanceMonitoring {
         sync: span.sync,
         start: span._start - transactionStart,
         duration: span.duration(),
-        context: context
+        context
       }
     })
 
-    var context = merge({}, configContext, transaction.context)
+    const context = merge({}, configContext, transaction.context)
     return {
       id: transaction.id,
       trace_id: transaction.traceId,
       name: sanitizeString(transaction.name, stringLimit, false),
       type: sanitizeString(transaction.type, stringLimit, true),
       duration: transaction.duration(),
-      spans: spans,
-      context: context,
+      spans,
+      context,
       marks: transaction.marks,
       span_count: {
         started: spans.length

--- a/src/performance-monitoring/transaction.js
+++ b/src/performance-monitoring/transaction.js
@@ -54,10 +54,10 @@ class Transaction extends SpanBase {
   }
 
   addNavigationTimingMarks () {
-    var marks = getNavigationTimingMarks()
-    var paintMarks = getPaintTimingMarks()
+    const marks = getNavigationTimingMarks()
+    const paintMarks = getPaintTimingMarks()
     if (marks) {
-      var agent = {
+      const agent = {
         timeToFirstByte: marks.responseStart,
         domInteractive: marks.domInteractive,
         domComplete: marks.domComplete
@@ -74,9 +74,9 @@ class Transaction extends SpanBase {
   }
 
   mark (key) {
-    var skey = removeInvalidChars(key)
-    var now = window.performance.now() - this._start
-    var custom = {}
+    const skey = removeInvalidChars(key)
+    const now = window.performance.now() - this._start
+    const custom = {}
     custom[skey] = now
     this.addMarks({ custom })
   }
@@ -91,11 +91,10 @@ class Transaction extends SpanBase {
     if (this.ended) {
       return
     }
-    var transaction = this
-    var opts = extend({}, options)
+    const opts = extend({}, options)
 
-    opts.onEnd = function (trc) {
-      transaction._onSpanEnd(trc)
+    opts.onEnd = trc => {
+      this._onSpanEnd(trc)
     }
     opts.traceId = this.traceId
     opts.sampled = this.sampled
@@ -104,15 +103,14 @@ class Transaction extends SpanBase {
       opts.parentId = this.id
     }
 
-    var span = new Span(name, type, opts)
+    const span = new Span(name, type, opts)
     this._activeSpans[span.id] = span
 
     return span
   }
 
   isFinished () {
-    var scheduledTasks = Object.keys(this._scheduledTasks)
-    return scheduledTasks.length === 0
+    return Object.keys(this._scheduledTasks).length === 0
   }
 
   detectFinish () {
@@ -126,13 +124,13 @@ class Transaction extends SpanBase {
     this.ended = true
     this._end = window.performance.now()
     // truncate active spans
-    for (var sid in this._activeSpans) {
-      var span = this._activeSpans[sid]
+    for (let sid in this._activeSpans) {
+      const span = this._activeSpans[sid]
       span.type = span.type + '.truncated'
       span.end()
     }
 
-    var metadata = getPageMetadata()
+    const metadata = getPageMetadata()
     this.addContext(metadata)
 
     this._adjustStartToEarliestSpan()
@@ -169,15 +167,15 @@ class Transaction extends SpanBase {
   }
 
   _adjustEndToLatestSpan () {
-    var latestSpan = findLatestNonXHRSpan(this.spans)
+    const latestSpan = findLatestNonXHRSpan(this.spans)
 
     if (latestSpan) {
       this._end = latestSpan._end
 
       // set all spans that now are longer than the transaction to
       // be truncated spans
-      for (var i = 0; i < this.spans.length; i++) {
-        var span = this.spans[i]
+      for (let i = 0; i < this.spans.length; i++) {
+        const span = this.spans[i]
         if (span._end > this._end) {
           span._end = this._end
           span.type = span.type + '.truncated'
@@ -190,7 +188,7 @@ class Transaction extends SpanBase {
   }
 
   _adjustStartToEarliestSpan () {
-    var span = getEarliestSpan(this.spans)
+    const span = getEarliestSpan(this.spans)
 
     if (span && span._start < this._start) {
       this._start = span._start
@@ -199,9 +197,9 @@ class Transaction extends SpanBase {
 }
 
 function findLatestNonXHRSpan (spans) {
-  var latestSpan = null
-  for (var i = 0; i < spans.length; i++) {
-    var span = spans[i]
+  let latestSpan = null
+  for (let i = 0; i < spans.length; i++) {
+    const span = spans[i]
     if (
       span.type &&
       span.type.indexOf('ext') === -1 &&
@@ -215,7 +213,7 @@ function findLatestNonXHRSpan (spans) {
 }
 
 function getEarliestSpan (spans) {
-  var earliestSpan = null
+  let earliestSpan = null
 
   spans.forEach(function (span) {
     if (!earliestSpan) {


### PR DESCRIPTION
+ Resource timing entries name have fully resolved URL as part of the SPEC and we dont really need to  parse them again based on the window base URL. 

+ The context information is sent only when the Entry Name is different from Span name -> Happens when the resource contains query strings in URL. small optimisation for reducing the payload to APM server. 